### PR TITLE
Remove ynh_store_file_checksum

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -167,13 +167,6 @@ ynh_script_progression --message="Configuring a systemd service..." --weight=1
 ynh_add_systemd_config --others_var="port tls_port domain env_path"
 
 #=================================================
-# STORE THE CONFIG FILE CHECKSUM
-#=================================================
-
-# Calculate and store the config file checksum into the app settings
-ynh_store_file_checksum --file="$final_path/dendrite.yaml"
-
-#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SECURE FILES AND DIRECTORIES


### PR DESCRIPTION
`ynh_store_file_checksum`is done with `ynh_add_config` helper :
https://github.com/YunoHost/yunohost/blob/adc83b4c9c2c30e9ef75f3609c538b646f91f1db/data/helpers.d/utils#L328