### PR TITLE
Upgrade to v0.9.6 and fix server_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Shipped version:** 0.9.5~ynh1
+**Shipped version:** 0.9.6~ynh1
 
 ## Disclaimers / important information
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,7 +24,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Version incluse :** 0.9.5~ynh1
+**Version incluse :** 0.9.6~ynh1
 
 ## Avertissements / informations importantes
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://api.github.com/repos/matrix-org/dendrite/tarball/v0.9.5
-SOURCE_SUM=222c1dec7ea18f7f0d86651112933abb25738ef0c9493757569d5dc4301b0813
+SOURCE_URL=https://api.github.com/repos/matrix-org/dendrite/tarball/v0.9.6
+SOURCE_SUM=b300e5f5da28872af08aade0868c132d81c2707edd6c3e9cd76a136292795c72
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/dendrite.yaml
+++ b/conf/dendrite.yaml
@@ -33,7 +33,7 @@ version: 2
 # Global Matrix configuration. This configuration applies to all components.
 global:
   # The domain name of this homeserver.
-  server_name: __DOMAIN__
+  server_name: __SERVER_NAME__
 
   # The path to the signing private key file, used to sign requests and events.
   # Note that this is NOT the same private key as used for TLS! To generate a

--- a/manifest.json
+++ b/manifest.json
@@ -40,23 +40,27 @@
                 "name": "domain",
                 "type": "domain",
                 "help": {
-                    "en": "Select the domain onto which Dendrite will be exclusively installed. It may be different than the displayed server name.",
-                    "fr": "Sélectionnez le domaine exclusivement dédié à Dendrite. Il peut être différent du nom d'affichage du serveur."
+                    "en": "Select the domain onto which Dendrite will be exclusively installed, e.g. dendrite.domain.tld",
+                    "fr": "Sélectionnez le domaine exclusivement dédié à Dendrite, par exemple dendrite.domain.tld"
                 }
             },
             {
                 "name": "server_name",
                 "type": "domain",
+                "ask": {
+                    "en": "Select the display name for your Dendrite server",
+                    "fr": "Sélectionnez le nom d'affichage pour votre serveur Dendrite"
+                },
                 "help": {
-                    "en": "If your Dendrite domain selected above is a subdomain, you can choose a different display name for your Dendrite server to have your Matrix user-ids looking like @user:domain.org instead of @user:dendrite.domain.org",
-                    "fr": "Si votre domaine pour Dendrite sélectionné précedemment est un sous-domaine, vous pouvez choisir un nom d'affichage pour votre serveur Dendrite afin que vos identifiants Matrix soient @utilisateur:domain.org plutôt que @utilisateur:dendrite.domain.org"
+                    "en": "If you choose domain.tld, your Matrix user-ids will be looking like @user:domain.tld instead of @user:dendrite.domain.tld",
+                    "fr": "Si vous choisissez domain.tld, vos identifiants Matrix ressembleront à @utilisateur:domain.tld plutôt que @utilisateur:dendrite.domain.tld"
                 }
             },
             {
                 "name": "registration",
                 "type": "boolean",
                 "default": false,
-                "help": {
+                "ask": {
                     "en": "Should the server allow any visitor to register as a user?",
                     "fr": "Le serveur doit-il permettre à quiconque de s'enregistrer comme utilisateur?"
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix homeserver of second generation",
         "fr": "Serveur Matrix de seconde génération"
     },
-    "version": "0.9.5~ynh1",
+    "version": "0.9.6~ynh1",
     "url": "https://matrix.org/",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -35,6 +35,17 @@ domain=$YNH_APP_NEW_DOMAIN
 server_name=$(ynh_app_setting_get --app=$app --key=server_name)
 port=$(ynh_app_setting_get --app=$app --key=port)
 tls_port=$(ynh_app_setting_get --app=$app --key=tls_port)
+registration=$(ynh_app_setting_get --app=$app --key=registration)
+
+# Load up registration variables
+if [[ $registration -eq 1 ]]
+then
+        registration_disabled="false"
+        really_enable_open_registration="--really-enable-open-registration"
+else
+        registration_disabled="true"
+        really_enable_open_registration=""
+fi
 
 #=================================================
 # BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -89,7 +89,7 @@ fi
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --line_match="Stopped Dendrite Matrix homeserver" --log_path="systemd"
+ynh_systemd_action --service_name=$app --action="stop" --line_match="Stopped Dendrite Matrix homeserver" --log_path="/var/log/$app/Monolith.log"
 
 #=================================================
 # MODIFY URL IN NGINX CONF

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -57,7 +57,7 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --line_match="Stopped external Monolith listener" --log_path="systemd"
+ynh_systemd_action --service_name=$app --action="stop" --line_match="Stopped external Monolith listener" --log_path="/var/log/$app/Monolith.log"
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY


### PR DESCRIPTION
## Problem

- New version released
- The server_name setting was not being applied into the configuration

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
