### PR TITLE
[Absolutely not urgent] Bump Go 1.20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Shipped version:** 0.11.1~ynh1
+**Shipped version:** 0.11.1~ynh2
 ## Disclaimers / important information
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Version incluse :** 0.11.1~ynh1
+**Version incluse :** 0.11.1~ynh2
 ## Avertissements / informations importantes
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix homeserver of second generation",
         "fr": "Serveur Matrix de seconde génération"
     },
-    "version": "0.11.1~ynh1",
+    "version": "0.11.1~ynh2",
     "url": "https://matrix.org/",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,7 +7,7 @@
 # dependencies used by the app (must be on a single line)
 pkg_dependencies="postgresql postgresql-contrib"
 
-GO_VERSION="1.18"
+GO_VERSION="1.20"
 psql_version=$PSQL_VERSION
 
 #=================================================


### PR DESCRIPTION
## Problem

As of [v0.11.1](https://github.com/matrix-org/dendrite/blob/main/CHANGES.md#dendrite-0111-2023-02-10) `dendrite` can be compiled with Go 1.20 and I see no reason why it shouldn't.

This probably gives no advantages and can safely be incorporated in some upcoming MR.

## Solution

- Bumped referenced Go version to 1.20.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
