### PR TITLE
Upgrade dendrite to v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Shipped version:** 0.11.1~ynh2
+**Shipped version:** 0.12.0~ynh1
 ## Disclaimers / important information
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Version incluse :** 0.11.1~ynh2
+**Version incluse :** 0.12.0~ynh1
 ## Avertissements / informations importantes
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://api.github.com/repos/matrix-org/dendrite/tarball/v0.11.1
-SOURCE_SUM=caf5df07a1dce5dbaa3133c939a8622893529d2f5dfd6b2a14ec97f7a4ec00f4
+SOURCE_URL=https://api.github.com/repos/matrix-org/dendrite/tarball/v0.12.0
+SOURCE_SUM=a50fba39dbbfe4de58674e448e7d1149359759f526bd366c3976547d9744953c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/
-ExecStart=__FINALPATH__/bin/dendrite-monolith-server --tls-cert=/etc/yunohost/certs/__DOMAIN__/crt.pem --tls-key=/etc/yunohost/certs/__DOMAIN__/key.pem --config=dendrite.yaml --http-bind-address=:__PORT__ --https-bind-address=:__TLS_PORT__ __REALLY_ENABLE_OPEN_REGISTRATION__
+ExecStart=__FINALPATH__/bin/dendrite --tls-cert=/etc/yunohost/certs/__DOMAIN__/crt.pem --tls-key=/etc/yunohost/certs/__DOMAIN__/key.pem --config=dendrite.yaml --http-bind-address=:__PORT__ --https-bind-address=:__TLS_PORT__ __REALLY_ENABLE_OPEN_REGISTRATION__
 StandardOutput=journal
 StandardError=inherit
 LimitNOFILE=65535

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix homeserver of second generation",
         "fr": "Serveur Matrix de seconde génération"
     },
-    "version": "0.11.1~ynh2",
+    "version": "0.12.0~ynh1",
     "url": "https://matrix.org/",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/install
+++ b/scripts/install
@@ -146,7 +146,7 @@ pushd "$final_path/build"
 	ynh_use_go
 	export GOPATH="$final_path/build/go"
 	export GOCACHE="$final_path/build/.cache"
-	CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/dendrite-monolith-server > /dev/null 2>&1
+	CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/dendrite > /dev/null 2>&1
 	CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/create-account > /dev/null 2>&1
 	CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/generate-keys > /dev/null 2>&1
 popd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -168,7 +168,7 @@ then
 		ynh_use_go
 		export GOPATH="$final_path/build/go"
 		export GOCACHE="$final_path/build/.cache"
-		CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/dendrite-monolith-server > /dev/null 2>&1
+		CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/dendrite > /dev/null 2>&1
 		CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/create-account > /dev/null 2>&1
 		CGO_ENABLED=1 go build -trimpath -v -o "$final_path/bin/" ./cmd/generate-keys > /dev/null 2>&1
 	popd


### PR DESCRIPTION
## Problem

As per [release notes for v0.12.0](https://github.com/matrix-org/dendrite/releases/tag/v0.12.0) dendrite polylith is now gone, hence executable for monolith got simplified to `dendrite`.
This PR (hopefully) incorporates necessary script changes.

## Solution

Manually edited `install` and `upgrade` scripts as well as service definition.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
