### PR TITLE
Properly monitor system start/stop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Shipped version:** 0.12.0~ynh1
+**Shipped version:** 0.12.0~ynh2
 ## Disclaimers / important information
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ Dendrite is a second-generation Matrix homeserver written in Go. It intends to p
 - Scalable: can run on multiple machines and eventually scale to massive homeserver deployments.
 
 
-**Version incluse :** 0.12.0~ynh1
+**Version incluse :** 0.12.0~ynh2
 ## Avertissements / informations importantes
 
 :warning: The upstream app is still in beta. Tread carefully.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Matrix homeserver of second generation",
         "fr": "Serveur Matrix de seconde génération"
     },
-    "version": "0.12.0~ynh1",
+    "version": "0.12.0~ynh2",
     "url": "https://matrix.org/",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -89,7 +89,7 @@ fi
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --line_match="Dendrite is exiting now" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="stop" --line_match="Dendrite is exiting now" --log_path="systemd"
 
 #=================================================
 # MODIFY URL IN NGINX CONF
@@ -138,7 +138,7 @@ ynh_add_systemd_config
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --line_match="Starting external Monolith listener" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="start" --line_match="Cleaning old notifications" --log_path="systemd"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/config
+++ b/scripts/config
@@ -46,7 +46,7 @@ ynh_app_config_apply() {
 
         ynh_add_config --template="../conf/dendrite.yaml" --destination="$final_path/dendrite.yaml"
         ynh_add_systemd_config
-        ynh_systemd_action --service_name=$app --action="restart" --line_match="Starting external Monolith listener" --log_path="/var/log/$app/$app.log"
+        ynh_systemd_action --service_name=$app --action="restart" --line_match="Cleaning old notifications" --log_path="systemd"
         ynh_app_setting_set --app=$app --key=registration --value=$registration
 
     fi

--- a/scripts/install
+++ b/scripts/install
@@ -214,7 +214,7 @@ yunohost service add $app --description="Dendrite Matrix homeserver" --log="/var
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --line_match="Starting external Monolith listener" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="start" --line_match="Cleaning old notifications" --log_path="systemd"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -139,7 +139,7 @@ yunohost service add $app --description="Dendrite Matrix homeserver" --log="/var
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --line_match="Starting external Monolith listener" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="start" --line_match="Cleaning old notifications" --log_path="systemd"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -56,7 +56,7 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --line_match="Dendrite is exiting now" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="stop" --line_match="Dendrite is exiting now" --log_path="systemd"
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -222,7 +222,7 @@ yunohost service add $app --description="Dendrite Matrix homeserver" --log="/var
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --line_match="Starting external Monolith listener" --log_path="/var/log/$app/Monolith.log"
+ynh_systemd_action --service_name=$app --action="start" --line_match="Cleaning old notifications" --log_path="systemd"
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

I've observed that dendrite upgrades will involve long pauses [like in this log](https://paste.yunohost.org/raw/epufovucox)

> The service dendrite didn't fully executed the action stop before the timeout.

This is because it's currently relying on monitoring `/var/log/dendrite/Monolith.log`. The text requested is logged with level `info` while the file appender runs with level `warn`. 

## Solution

By using `systemd` special log file we can monitor using `journalctl`. What's more I've changed successful startup string as the old one referring to Monolith server does not occur currently. See [new log](https://paste.yunohost.org/raw/qeyutavuqa) with updated calls to `ynh_systemd_action`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
