### PR TITLE
server_name.conf: remove trailing comma

### DIFF
--- a/conf/server_name.conf
+++ b/conf/server_name.conf
@@ -6,7 +6,7 @@ location /.well-known/matrix/server {
 
 location /.well-known/matrix/client {
     return 200 '{
-        "m.homeserver": { "base_url": "https://__DOMAIN__" },
+        "m.homeserver": { "base_url": "https://__DOMAIN__" }
     }';
     add_header Content-Type application/json;
     add_header Access-Control-Allow-Origin '*';


### PR DESCRIPTION
The JSON is invalid and breaks with clients that use this (example: NeoChat)

## Problem

The comma makes the json invalid, and the endpoint unusable

## Solution

Remove the comma

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)