### PR TITLE
Give higher .well-known priority vs nextcloud

### DIFF
--- a/conf/server_name.conf
+++ b/conf/server_name.conf
@@ -1,10 +1,10 @@
-location /.well-known/matrix/server {
+location = /.well-known/matrix/server {
     return 200 '{"m.server": "__DOMAIN__:__PORT_TLS__"}';
     add_header Content-Type application/json;
     add_header Access-Control-Allow-Origin '*';
 }
 
-location /.well-known/matrix/client {
+location = /.well-known/matrix/client {
     return 200 '{
         "m.homeserver": { "base_url": "https://__DOMAIN__" }
     }';


### PR DESCRIPTION
## Problem

Nextcloud uses a `location ^~ /.well-known {` block, which will supersede simple `location /.well-known/...` blocks from this app if they happen to be installed on the same domain.

## Solution

Replace this app's block by `location = /.well-known`, which has higher priority.
cf. https://docs.nginx.com/nginx/admin-guide/web-server/web-server/#nginx-location-priority

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
